### PR TITLE
Add logout response DTO and update service

### DIFF
--- a/FA25_CusomMapOSM_BE/CusomMapOSM_API/Endpoints/Authentication/AuthenticationEndpoint.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_API/Endpoints/Authentication/AuthenticationEndpoint.cs
@@ -3,6 +3,7 @@ using CusomMapOSM_API.Extensions;
 using CusomMapOSM_API.Interfaces;
 using CusomMapOSM_Application.Interfaces.Features.Authentication;
 using CusomMapOSM_Application.Models.DTOs.Features.Authentication.Request;
+using CusomMapOSM_Application.Models.DTOs.Features.Authentication.Response;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CusomMapOSM_API.Endpoints.Authentication;

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Interfaces/Features/Authentication/IAuthenticationService.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Interfaces/Features/Authentication/IAuthenticationService.cs
@@ -7,7 +7,7 @@ namespace CusomMapOSM_Application.Interfaces.Features.Authentication;
 public interface IAuthenticationService
 {
     Task<Option<LoginResDto, Error>> Login(LoginReqDto req);
-    Task<Option<RegisterResDto, Error>> LogOut(Guid userId);
+    Task<Option<LogoutResDto, Error>> LogOut(Guid userId);
     Task<Option<RegisterResDto, Error>> VerifyEmail(RegisterVerifyReqDto req);
     Task<Option<RegisterResDto, Error>> VerifyOtp(VerifyOtpReqDto req);
     Task<Option<RegisterResDto, Error>> ResetPasswordVerify(ResetPasswordVerifyReqDto req);

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Models/DTOs/Features/Authentication/Response/Response.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Models/DTOs/Features/Authentication/Response/Response.cs
@@ -15,3 +15,8 @@ public record RegisterVerifyOtpResDto
     public required string Email { get; set; }
     public required string Otp { get; set; }
 }
+
+public record LogoutResDto
+{
+    public required string Result { get; set; }
+}

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/Features/Authentication/AuthenticationService.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/Features/Authentication/AuthenticationService.cs
@@ -48,11 +48,11 @@ public class AuthenticationService : IAuthenticationService
         return Option.Some<LoginResDto, Error>(new LoginResDto { Token = token });
     }
 
-    public async Task<Option<RegisterResDto, Error>> LogOut(Guid userId)
+    public async Task<Option<LogoutResDto, Error>> LogOut(Guid userId)
     {
         var user = await _authenticationRepository.GetUserById(userId);
         if (user is null)
-            return Option.None<RegisterResDto, Error>(new Error("Authentication.UserNotFound", "User not found", ErrorType.NotFound));
+            return Option.None<LogoutResDto, Error>(new Error("Authentication.UserNotFound", "User not found", ErrorType.NotFound));
 
         var accountStatus = await _typeRepository.GetAccountStatusById(AccountStatusEnum.Inactive);
 
@@ -62,7 +62,7 @@ public class AuthenticationService : IAuthenticationService
 
         await _redisCacheService.ForceLogout(userId);
 
-        return Option.Some<RegisterResDto, Error>(new RegisterResDto { Result = "Logout successfully" });
+        return Option.Some<LogoutResDto, Error>(new LogoutResDto { Result = "Logout successfully" });
     }
 
     public async Task<Option<RegisterResDto, Error>> VerifyEmail(RegisterVerifyReqDto req)


### PR DESCRIPTION
## Summary
- add LogoutResDto to encapsulate logout results
- update authentication service interface and implementation to return LogoutResDto
- import new response DTO in authentication endpoint

## Testing
- `dotnet test FA25_CusomMapOSM_BE/FA25_CusomMapOSM_BE.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68961673a6e4832d9c6d9461bacfe24d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new logout response type for authentication actions.

* **Bug Fixes**
  * Improved the accuracy of logout responses to provide clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->