### PR TITLE
feat(osm): add query service for overpass API

### DIFF
--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Application/DependencyInjections.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Application/DependencyInjections.cs
@@ -64,6 +64,8 @@ public static class DependencyInjections
             options.QueueLimit = 2;
         }));
 
+        services.AddHttpClient();
+
         // Register Services
 
         return services;

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Interfaces/Features/Osm/IOsmQueryService.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Interfaces/Features/Osm/IOsmQueryService.cs
@@ -1,0 +1,11 @@
+using CusomMapOSM_Application.Common.Errors;
+using CusomMapOSM_Application.Models.DTOs.Features.Osm;
+using Optional;
+
+namespace CusomMapOSM_Application.Interfaces.Features.Osm;
+
+public interface IOsmQueryService
+{
+    Task<Option<OsmQueryResDto, Error>> QueryByBoundingBox(double south, double west, double north, double east, string filter);
+    Task<Option<OsmQueryResDto, Error>> QueryByCoordinates(double latitude, double longitude, double radius, string filter);
+}

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Models/DTOs/Features/Osm/Response.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Models/DTOs/Features/Osm/Response.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace CusomMapOSM_Application.Models.DTOs.Features.Osm;
+
+public record OsmElementDto
+{
+    public required string Type { get; set; }
+    public long Id { get; set; }
+    public double? Lat { get; set; }
+    public double? Lon { get; set; }
+    public Dictionary<string, string>? Tags { get; set; }
+}
+
+public record OsmQueryResDto
+{
+    public required List<OsmElementDto> Elements { get; set; } = new();
+}

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/DependencyInjections.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/DependencyInjections.cs
@@ -1,6 +1,7 @@
 ﻿using CusomMapOSM_Application.Interfaces.Features.Authentication;
 using CusomMapOSM_Application.Interfaces.Services.Cache;
 using CusomMapOSM_Application.Interfaces.Services.Jwt;
+using CusomMapOSM_Application.Interfaces.Features.Osm;
 using CusomMapOSM_Application.Interfaces.Services.Mail;
 using CusomMapOSM_Infrastructure.Databases;
 using CusomMapOSM_Infrastructure.Databases.Repositories.Implementations.Authentication;
@@ -9,6 +10,7 @@ using CusomMapOSM_Infrastructure.Databases.Repositories.Interfaces.Authenticatio
 using CusomMapOSM_Infrastructure.Databases.Repositories.Interfaces.Type;
 using CusomMapOSM_Infrastructure.Features.Authentication;
 using CusomMapOSM_Infrastructure.Services;
+using CusomMapOSM_Infrastructure.Features.Osm;
 using CusomMapOSM_Shared.Constant;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -57,6 +59,7 @@ public static class DependencyInjections
         services.AddScoped<IRedisCacheService, RedisCacheService>();
 
         services.AddScoped<IAuthenticationService, AuthenticationService>();
+        services.AddHttpClient<IOsmQueryService, OsmQueryService>();
 
         // Register Redis Cache
         services.AddSingleton<IConnectionMultiplexer>(sp =>

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/Features/Osm/OsmQueryService.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/Features/Osm/OsmQueryService.cs
@@ -1,0 +1,67 @@
+using CusomMapOSM_Application.Common.Errors;
+using CusomMapOSM_Application.Interfaces.Features.Osm;
+using CusomMapOSM_Application.Models.DTOs.Features.Osm;
+using Newtonsoft.Json;
+using Optional;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace CusomMapOSM_Infrastructure.Features.Osm;
+
+public class OsmQueryService : IOsmQueryService
+{
+    private readonly HttpClient _httpClient;
+    private const string OVERPASS_API = "https://overpass-api.de/api/interpreter";
+
+    public OsmQueryService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<Option<OsmQueryResDto, Error>> QueryByBoundingBox(double south, double west, double north, double east, string filter)
+    {
+        var query = BuildBoundingBoxQuery(south, west, north, east, filter);
+        return await ExecuteQuery(query);
+    }
+
+    public async Task<Option<OsmQueryResDto, Error>> QueryByCoordinates(double latitude, double longitude, double radius, string filter)
+    {
+        var query = BuildCoordinateQuery(latitude, longitude, radius, filter);
+        return await ExecuteQuery(query);
+    }
+
+    private async Task<Option<OsmQueryResDto, Error>> ExecuteQuery(string query)
+    {
+        try
+        {
+            var content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("data", query)
+            });
+
+            var response = await _httpClient.PostAsync(OVERPASS_API, content);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<OsmQueryResDto>(json);
+            if (result is null)
+                return Option.None<OsmQueryResDto, Error>(Error.Failure("OsmQuery.Empty", "Empty response from Overpass API"));
+
+            return Option.Some<OsmQueryResDto, Error>(result);
+        }
+        catch (Exception ex)
+        {
+            return Option.None<OsmQueryResDto, Error>(Error.Problem("OsmQuery.Error", ex.Message));
+        }
+    }
+
+    private static string BuildBoundingBoxQuery(double south, double west, double north, double east, string filter)
+    {
+        return $"[out:json];{filter}({south},{west},{north},{east});out body;";
+    }
+
+    private static string BuildCoordinateQuery(double lat, double lon, double radius, string filter)
+    {
+        return $"[out:json];{filter}(around:{radius},{lat},{lon});out body;";
+    }
+}


### PR DESCRIPTION
## Summary
- add IOsmQueryService interface and DTOs
- implement OsmQueryService using Overpass API
- register IOsmQueryService in DI for application and infrastructure

## Testing
- `dotnet build FA25_CusomMapOSM_BE/FA25_CusomMapOSM_BE.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden for ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68961c49b240832d96be05a4c7662603