### PR TITLE
feat: add OSM query endpoints

### DIFF
--- a/FA25_CusomMapOSM_BE/CusomMapOSM_API/Endpoints/OsmQueryEndpoint.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_API/Endpoints/OsmQueryEndpoint.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using CusomMapOSM_API.Interfaces;
+using CusomMapOSM_Application.Interfaces.Services.Osm;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CusomMapOSM_API.Endpoints;
+
+public class OsmQueryEndpoint : IEndpoint
+{
+    private const string API_PREFIX = "osm";
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup(API_PREFIX)
+            .WithTags(Tags.Osm);
+
+        group.MapGet("/bbox", async (
+            [FromQuery] double south,
+            [FromQuery] double west,
+            [FromQuery] double north,
+            [FromQuery] double east,
+            [FromServices] IOsmQueryService osmService) =>
+        {
+            try
+            {
+                var json = await osmService.QueryBBox(south, west, north, east);
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("error", out var err) ||
+                    doc.RootElement.TryGetProperty("remark", out var remark))
+                {
+                    var message = err.ValueKind == JsonValueKind.String ? err.GetString() : remark.GetString();
+                    return Results.Problem(message);
+                }
+
+                var obj = JsonSerializer.Deserialize<object>(json);
+                return Results.Json(obj);
+            }
+            catch (Exception ex)
+            {
+                return Results.Problem(ex.Message);
+            }
+        })
+        .WithName("OsmQueryBBox")
+        .WithDescription("Query OSM data by bounding box");
+
+        group.MapGet("/points", async (
+            [FromQuery] List<string> points,
+            [FromServices] IOsmQueryService osmService) =>
+        {
+            if (points is null || points.Count == 0)
+                return Results.BadRequest("points parameter is required");
+
+            var coords = new List<(double lat, double lon)>();
+            foreach (var p in points)
+            {
+                var parts = p.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length != 2 ||
+                    !double.TryParse(parts[0], out var lat) ||
+                    !double.TryParse(parts[1], out var lon))
+                {
+                    return Results.BadRequest($"Invalid point format: {p}");
+                }
+                coords.Add((lat, lon));
+            }
+
+            try
+            {
+                var json = await osmService.QueryPoints(coords);
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("error", out var err) ||
+                    doc.RootElement.TryGetProperty("remark", out var remark))
+                {
+                    var message = err.ValueKind == JsonValueKind.String ? err.GetString() : remark.GetString();
+                    return Results.Problem(message);
+                }
+
+                var obj = JsonSerializer.Deserialize<object>(json);
+                return Results.Json(obj);
+            }
+            catch (Exception ex)
+            {
+                return Results.Problem(ex.Message);
+            }
+        })
+        .WithName("OsmQueryPoints")
+        .WithDescription("Query OSM data by list of points");
+    }
+}

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_API/Program.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_API/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddInfrastructureServices(builder.Configuration);
 builder.Services.AddApplicationServices();
 builder.Services.AddEndpoints();
 builder.Services.AddValidation();
+builder.Services.AddHttpClient();
 
 // Add swagger services to the container.
 builder.Services.AddSwaggerServices();
@@ -52,7 +53,7 @@ app.UseAuthentication();
 app.MapHealthChecks("/health");
 app.MapHealthChecks("/ready");
 
-// Map all endpoints
+// Map all endpoints including OSM queries
 app.MapEndpoints();
 
 app.Run();

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_API/Tags.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_API/Tags.cs
@@ -3,4 +3,5 @@
 internal static class Tags
 {
     internal const string Test = "Test";
+    internal const string Osm = "OSM";
 }

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Interfaces/Services/Osm/IOsmQueryService.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Interfaces/Services/Osm/IOsmQueryService.cs
@@ -1,0 +1,7 @@
+namespace CusomMapOSM_Application.Interfaces.Services.Osm;
+
+public interface IOsmQueryService
+{
+    Task<string> QueryBBox(double south, double west, double north, double east);
+    Task<string> QueryPoints(IEnumerable<(double lat, double lon)> points);
+}

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/DependencyInjections.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/DependencyInjections.cs
@@ -2,6 +2,7 @@
 using CusomMapOSM_Application.Interfaces.Services.Cache;
 using CusomMapOSM_Application.Interfaces.Services.Jwt;
 using CusomMapOSM_Application.Interfaces.Services.Mail;
+using CusomMapOSM_Application.Interfaces.Services.Osm;
 using CusomMapOSM_Infrastructure.Databases;
 using CusomMapOSM_Infrastructure.Databases.Repositories.Implementations.Authentication;
 using CusomMapOSM_Infrastructure.Databases.Repositories.Implementations.Type;
@@ -57,6 +58,7 @@ public static class DependencyInjections
         services.AddScoped<IRedisCacheService, RedisCacheService>();
 
         services.AddScoped<IAuthenticationService, AuthenticationService>();
+        services.AddHttpClient<IOsmQueryService, OsmQueryService>();
 
         // Register Redis Cache
         services.AddSingleton<IConnectionMultiplexer>(sp =>

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/Services/OsmQueryService.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/Services/OsmQueryService.cs
@@ -1,0 +1,33 @@
+using System.Text;
+using System.Linq;
+using CusomMapOSM_Application.Interfaces.Services.Osm;
+
+namespace CusomMapOSM_Infrastructure.Services;
+
+public class OsmQueryService : IOsmQueryService
+{
+    private readonly HttpClient _httpClient;
+    private const string OVERPASS_API = "https://overpass-api.de/api/interpreter";
+
+    public OsmQueryService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<string> QueryBBox(double south, double west, double north, double east)
+    {
+        var query = $"[out:json];node({south},{west},{north},{east});out;";
+        var content = new StringContent(query, Encoding.UTF8, "application/x-www-form-urlencoded");
+        var response = await _httpClient.PostAsync(OVERPASS_API, content);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    public async Task<string> QueryPoints(IEnumerable<(double lat, double lon)> points)
+    {
+        var poly = string.Join(" ", points.Select(p => $"{p.lat} {p.lon}"));
+        var query = $"[out:json];node(poly:\"{poly}\");out;";
+        var content = new StringContent(query, Encoding.UTF8, "application/x-www-form-urlencoded");
+        var response = await _httpClient.PostAsync(OVERPASS_API, content);
+        return await response.Content.ReadAsStringAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- add OSM query API endpoints
- implement and register OsmQueryService
- wire up service with dependency injection

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68961c4f75b8832daca3d7e2f39c5171