### PR TITLE
Add Overpass caching with Redis

### DIFF
--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Interfaces/Services/Overpass/IOverpassService.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Application/Interfaces/Services/Overpass/IOverpassService.cs
@@ -1,0 +1,7 @@
+namespace CusomMapOSM_Application.Interfaces.Services.Overpass;
+
+public interface IOverpassService
+{
+    Task<string> GetDataByBoundingBoxAsync(double south, double west, double north, double east);
+    Task<string> GetDataByCoordinatesAsync(IEnumerable<(double lat, double lon)> points);
+}

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/DependencyInjections.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/DependencyInjections.cs
@@ -2,6 +2,7 @@
 using CusomMapOSM_Application.Interfaces.Services.Cache;
 using CusomMapOSM_Application.Interfaces.Services.Jwt;
 using CusomMapOSM_Application.Interfaces.Services.Mail;
+using CusomMapOSM_Application.Interfaces.Services.Overpass;
 using CusomMapOSM_Infrastructure.Databases;
 using CusomMapOSM_Infrastructure.Databases.Repositories.Implementations.Authentication;
 using CusomMapOSM_Infrastructure.Databases.Repositories.Implementations.Type;
@@ -55,6 +56,7 @@ public static class DependencyInjections
         services.AddScoped<IJwtService, JwtService>();
         services.AddScoped<IMailService, MailService>();
         services.AddScoped<IRedisCacheService, RedisCacheService>();
+        services.AddHttpClient<IOverpassService, OverpassService>();
 
         services.AddScoped<IAuthenticationService, AuthenticationService>();
 

--- a/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/Services/OverpassService.cs
+++ b/FA25_CusomMapOSM_BE/CusomMapOSM_Infrastructure/Services/OverpassService.cs
@@ -1,0 +1,72 @@
+using System.Net.Http;
+using System.Text;
+using System.Linq;
+using CusomMapOSM_Application.Interfaces.Services.Cache;
+using CusomMapOSM_Application.Interfaces.Services.Overpass;
+using Microsoft.Extensions.Logging;
+
+namespace CusomMapOSM_Infrastructure.Services;
+
+public class OverpassService : IOverpassService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IRedisCacheService _cacheService;
+    private readonly ILogger<OverpassService> _logger;
+
+    private static int _cacheHitCount;
+    private static int _cacheMissCount;
+
+    public OverpassService(HttpClient httpClient, IRedisCacheService cacheService, ILogger<OverpassService> logger)
+    {
+        _httpClient = httpClient;
+        _cacheService = cacheService;
+        _logger = logger;
+        _httpClient.BaseAddress ??= new Uri("https://overpass-api.de/api/");
+    }
+
+    public async Task<string> GetDataByBoundingBoxAsync(double south, double west, double north, double east)
+    {
+        var cacheKey = $"bbox:{south}:{west}:{north}:{east}";
+        var cached = await _cacheService.Get<string>(cacheKey);
+        if (!string.IsNullOrEmpty(cached))
+        {
+            _cacheHitCount++;
+            _logger.LogInformation("Overpass cache hit for {Key}. HitCount: {HitCount}", cacheKey, _cacheHitCount);
+            return cached;
+        }
+
+        _cacheMissCount++;
+        _logger.LogInformation("Overpass cache miss for {Key}. MissCount: {MissCount}", cacheKey, _cacheMissCount);
+
+        var query = $"[out:json];(node({south},{west},{north},{east});way({south},{west},{north},{east});relation({south},{west},{north},{east}););out body;>;out skel qt;";
+        var response = await _httpClient.PostAsync("interpreter", new StringContent(query, Encoding.UTF8, "application/x-www-form-urlencoded"));
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        await _cacheService.Set(cacheKey, content, TimeSpan.FromHours(1));
+        return content;
+    }
+
+    public async Task<string> GetDataByCoordinatesAsync(IEnumerable<(double lat, double lon)> points)
+    {
+        var pointKey = string.Join(";", points.Select(p => $"{p.lat},{p.lon}"));
+        var cacheKey = $"points:{pointKey}";
+        var cached = await _cacheService.Get<string>(cacheKey);
+        if (!string.IsNullOrEmpty(cached))
+        {
+            _cacheHitCount++;
+            _logger.LogInformation("Overpass cache hit for {Key}. HitCount: {HitCount}", cacheKey, _cacheHitCount);
+            return cached;
+        }
+
+        _cacheMissCount++;
+        _logger.LogInformation("Overpass cache miss for {Key}. MissCount: {MissCount}", cacheKey, _cacheMissCount);
+
+        var coordsString = string.Join(" ", points.Select(p => $"{p.lat} {p.lon}"));
+        var query = $"[out:json];(way(poly:\"{coordsString}\");>;);out;";
+        var response = await _httpClient.PostAsync("interpreter", new StringContent(query, Encoding.UTF8, "application/x-www-form-urlencoded"));
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        await _cacheService.Set(cacheKey, content, TimeSpan.FromHours(1));
+        return content;
+    }
+}


### PR DESCRIPTION
## Summary
- add Overpass service interface and implementation using Redis cache
- cache Overpass API responses with 1 hour TTL and log hit/miss counts
- register Overpass service in dependency injection

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68961c51010c832d8008bd13b73fb4d1